### PR TITLE
Make the plugin work with the newly released OS X Lion 10.7.2 with Termin

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,7 +28,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>MaxBundleVersion</key>
-			<string>297</string>
+			<string>299</string>
 			<key>MinBundleVersion</key>
 			<string>237</string>
 		</dict>


### PR DESCRIPTION
Make the plugin work with the newly released OS X Lion 10.7.2 with Terminal 2.2.1 Build 299
