### PR TITLE
compatibility fix for OS X 10.7.3

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,7 +28,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>MaxBundleVersion</key>
-			<string>299</string>
+			<string>303</string>
 			<key>MinBundleVersion</key>
 			<string>237</string>
 		</dict>


### PR DESCRIPTION
Updates MaxBundleVersion to 303 for Terminal 2.2.2
