### PR TITLE
Adding Terminal v2.3 (309) support

### DIFF
--- a/TerminalTabSwitching.bundle/Contents/Info.plist
+++ b/TerminalTabSwitching.bundle/Contents/Info.plist
@@ -26,7 +26,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>MaxBundleVersion</key>
-			<string>273</string>
+			<string>309</string>
 			<key>MinBundleVersion</key>
 			<string>237</string>
 		</dict>


### PR DESCRIPTION
Adding OS X Lion 10.8.5 support by changing the MaxBundleVersion to 309 does the trick.
