### PR TITLE
Scientifically update for El Capitan Terminal.app

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,7 +28,7 @@
 			<key>BundleIdentifier</key>
 			<string>com.apple.Terminal</string>
 			<key>MaxBundleVersion</key>
-			<string>343.7</string>
+			<string>362.0</string>
 			<key>MinBundleVersion</key>
 			<string>237</string>
 		</dict>


### PR DESCRIPTION
This PR bumps the maximum supported version of Terminal.app above what ships with El Capitan. I've verified that this change works with 10.11.

![Demo](http://g.recordit.co/vj3gJi3jZJ.gif)
